### PR TITLE
fix script due to output change

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -369,10 +369,10 @@ case "$deploy_type" in
     echo "Deploying Azure resources..."
 
     if [ "$(az account show --query 'user.type' -o tsv)" == "servicePrincipal" ]; then
-      CURRENT_USER_OBJECT_ID="$(az ad sp show --id "${servicePrincipalId}" --query 'objectId' -o tsv)"
+      CURRENT_USER_OBJECT_ID="$(az ad sp show --id "${servicePrincipalId}" --query 'id' -o tsv)"
     else
       CURRENT_USER_ID="$(az account show --query 'user.name' -o tsv)"
-      CURRENT_USER_OBJECT_ID="$(az ad user show --id "$CURRENT_USER_ID" --query objectId -o tsv)"
+      CURRENT_USER_OBJECT_ID="$(az ad user show --id "$CURRENT_USER_ID" --query id -o tsv)"
     fi
     echo "Current user object id: $CURRENT_USER_OBJECT_ID"
 


### PR DESCRIPTION
## script fix for output change

The output of `az ad user show --id "$CURRENT_USER_ID"` changed **objectId** to **id**

```
{
  "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#users/$entity",
  "businessPhones": [],
  "displayName": "<Name Here>",
  "givenName": "<name>",
  "id": "xxxxxxx",
  "jobTitle": null,
  "mail": null,
  "mobilePhone": null,
  "officeLocation": null,
  "preferredLanguage": null,
  "surname": "<here>",
  "userPrincipalName": "<Email>"
}
```

Without the account ID the bicep script wont add the key vault permissions 