### PR TITLE
updated version 1.27.7

### DIFF
--- a/azure/bicep/aks.bicep
+++ b/azure/bicep/aks.bicep
@@ -5,7 +5,7 @@ param clusterName string
 param location string = resourceGroup().location
 
 @description('Kubernetes version to use')
-param kubernetesVersion string = '1.27.1'
+param kubernetesVersion string = '1.27.7'
 
 @description('The VM Size to use for the platform')
 param platformNodeVm string


### PR DESCRIPTION
### Fix AKS minimum version 
For the following issue: 
```
Provisioning of resource(s) for container service oasis-enterprise in resource group {name} failed. Message: Version 1.27.1 is not supported in this region. Please use [az aks get-versions] command to get the supported version list in this region. For more information, please check 
```