### PR TITLE
Added example of Versioned PiWind deployments

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -283,7 +283,7 @@ function get_or_generate_secret {
   if ! az keyvault secret list --vault-name "$key_vault_name" --query "[].name" -o tsv | grep -q "$1"; then
     echo "Generating secret $1..." 1>&2
 
-    az keyvault secret set --vault-name "$key_vault_name" --name "$1" --value "$(< /dev/urandom tr -dc '_A-Z-a-z-0-9#=?+-' | head -c32)" --query "value" -o tsv
+    az keyvault secret set --vault-name "$key_vault_name" --name "$1" --value "$(< /dev/urandom tr -dc '_A-Z-a-z-0-9=?-' | head -c32)" --query "value" -o tsv
   else
     az keyvault secret show --vault-name "$key_vault_name" --name "$1" --query "value" -o tsv
   fi

--- a/settings/helm/workers/oasislmf-piwind-2.yaml
+++ b/settings/helm/workers/oasislmf-piwind-2.yaml
@@ -2,8 +2,8 @@ workers:
   oasislmf_piwind_1: # A name that is unique among all workers
     supplierId: OasisLMF  # Must be identical to supplier in the model data file share
     modelId: PiWind       # Must be identical to name in the model data file share
-    modelVersionId: "1"   # Must be identical to version in the model data file share
-    apiVersion: "v1"      # Single Server execution
+    modelVersionId: "2"   # Must be identical to version in the model data file share
+    apiVersion: "v2"      # Distributed exection
     image: ${ACR}/coreoasis/model_worker  # The path to your image, ${ACR} will automatically be replaced with your environments URL
     version: dev                          # Version tag of your image
     imagePullPolicy: Always

--- a/settings/helm/workers/oasislmf-piwind-2.yaml
+++ b/settings/helm/workers/oasislmf-piwind-2.yaml
@@ -1,5 +1,5 @@
 workers:
-  oasislmf_piwind_1: # A name that is unique among all workers
+  oasislmf_piwind_2: # A name that is unique among all workers
     supplierId: OasisLMF  # Must be identical to supplier in the model data file share
     modelId: PiWind       # Must be identical to name in the model data file share
     modelVersionId: "2"   # Must be identical to version in the model data file share

--- a/settings/helm/workers/oasislmf-piwind-2.yaml
+++ b/settings/helm/workers/oasislmf-piwind-2.yaml
@@ -2,7 +2,7 @@ workers:
   oasislmf_piwind_2: # A name that is unique among all workers
     supplierId: OasisLMF  # Must be identical to supplier in the model data file share
     modelId: PiWind       # Must be identical to name in the model data file share
-    modelVersionId: "1"   # Must be identical to version in the model data file share
+    modelVersionId: "2"   # Must be identical to version in the model data file share
     apiVersion: "v2"      # Distributed exection
     image: ${ACR}/coreoasis/model_worker  # The path to your image, ${ACR} will automatically be replaced with your environments URL
     version: dev                          # Version tag of your image

--- a/settings/helm/workers/oasislmf-piwind-2.yaml
+++ b/settings/helm/workers/oasislmf-piwind-2.yaml
@@ -2,7 +2,7 @@ workers:
   oasislmf_piwind_2: # A name that is unique among all workers
     supplierId: OasisLMF  # Must be identical to supplier in the model data file share
     modelId: PiWind       # Must be identical to name in the model data file share
-    modelVersionId: "2"   # Must be identical to version in the model data file share
+    modelVersionId: "1"   # Must be identical to version in the model data file share
     apiVersion: "v2"      # Distributed exection
     image: ${ACR}/coreoasis/model_worker  # The path to your image, ${ACR} will automatically be replaced with your environments URL
     version: dev                          # Version tag of your image


### PR DESCRIPTION
Updated deployment for PR https://github.com/OasisLMF/OasisPlatform/pull/931

This adds two deployments piwind, one for each API version `v1` and `v2`.  There is currently an issue with auto-scaling between both these deployments.  For testing disable the  `worker-controller` and manually scale the piwind deployments. 

```
$ kubectl scale --replicas=0 deployment/oasis-worker-controller
deployment.apps/oasis-worker-controller scaled
``` 

```
$ kubectl scale --replicas=1 deployment/worker-oasislmf-piwind-1-v1
deployment.apps/worker-oasislmf-piwind-1-v1 scaled
$ kubectl scale --replicas=1 deployment/worker-oasislmf-piwind-1-v2
deployment.apps/worker-oasislmf-piwind-1-v2 scaled
```
![Screenshot from 2023-12-14 11-57-18](https://github.com/OasisLMF/OasisAzureDeployment/assets/9889973/907a309f-3128-4678-b9fd-3111ef3a430a)

To edit the worker v1 image switch the tag in these lines, for example  `dev` -> `1.28.5` and rerun `./deploy.sh models`

https://github.com/OasisLMF/OasisAzureDeployment/blob/4fd55724cff7a42f9d8dd381349eca95214cd47e/settings/helm/workers/oasislmf-piwind-1.yaml#L2-L8

### Troubleshooting - Celery DB connection error 
If `v1` workers are crashing with the following error 
```
kubectl logs worker-oasislmf-piwind-1-v1-56977d8c49-q8t6m
Defaulted container "worker" out of: worker, init-tcp-wait-by-secret (init)
wait-for-it.sh: waiting 60 seconds for broker:5672
wait-for-it.sh: broker:5672 is available after 0 seconds
wait-for-it.sh: waiting 60 seconds for oasis-j25vz4tnmuh5m.privatelink.postgres.database.azure.com:5432
wait-for-it.sh: oasis-j25vz4tnmuh5m.privatelink.postgres.database.azure.com:5432 is available after 0 seconds
[2023-12-14 13:35:46,296: CRITICAL/MainProcess] Unrecoverable error: ValueError("Port could not be cast to integer value as '******' ")
```
The error is caused by special characters in celery password, tripping up the celery DB connection. Note that `v2` don't have this issue because they are escaped within the celery app. 

The easiest workaround is updating the celery password by deleting the `celery-db-password` entry from the Key Vault. 
![Screenshot from 2024-01-04 10-49-22](https://github.com/OasisLMF/OasisAzureDeployment/assets/9889973/389dd24e-bd2c-4b51-9026-aea8444efaf1)

Then rerunning the deployment `./deploy.sh base` using this branch, this generates a new password without the problematic characters.   