### PR TITLE
Fix OASIS_API_URL

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -233,7 +233,7 @@ function start_port_forward() {
   done
   echo "up"
 
-  export OASIS_API_URL="http://localhost:$PORT_FORWARDING_LOCAL_PORT"
+  export OASIS_API_URL="http://localhost:$PORT_FORWARDING_LOCAL_PORT/api"
 }
 
 function start_port_forward_if_needed() {


### PR DESCRIPTION
OASIS_API_URL is missing the path /api when doing a port forward of deploy/oasis-server