### PR TITLE
Stream container logs into Azure blob storage 

### DIFF
--- a/azure/bicep/blob_account.bicep
+++ b/azure/bicep/blob_account.bicep
@@ -101,13 +101,13 @@ resource blobFsNameSecret 'Microsoft.KeyVault/vaults/secrets@2021-06-01-preview'
   }
 }
 
-resource serverContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2021-04-01' = {
-  name: '${blobFs.name}/default/${serverContainerName}'
-}
-
-resource modelsContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2021-04-01' = {
-  name: '${blobFs.name}/default/${modelsContainerName}'
-}
+// resource serverContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2021-04-01' = {
+//   name: '${blobFs.name}/default/${serverContainerName}'
+// }
+// 
+// resource modelsContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2021-04-01' = {
+//   name: '${blobFs.name}/default/${modelsContainerName}'
+// }
 
 resource modelsContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2021-04-01' = {
   name: '${blobFs.name}/default/${logsContainerName}'
@@ -115,6 +115,6 @@ resource modelsContainer 'Microsoft.Storage/storageAccounts/blobServices/contain
 
 output oasisBlobNameSecretName string = oasisBlobNameSecretName
 output oasisBlobKeySecretName string = oasisBlobKeySecretName
-output serverBlobContainerName string = serverContainerName
-output modelsBlobContainerName string = modelsContainerName
-output logsBlobContainerName string = logsContainerName
+// output serverBlobContainerName string = serverContainerName
+// output modelsBlobContainerName string = modelsContainerName
+// output logsBlobContainerName string = logsContainerName

--- a/azure/bicep/blob_account.bicep
+++ b/azure/bicep/blob_account.bicep
@@ -27,10 +27,13 @@ param oasisBlobNameSecretName string = 'oasisblob-name'
 param oasisBlobKeySecretName string = 'oasisblob-key'
 
 @description('Blob Container name for oasis shared file system')
-param serverContainerName string = 'serverblobs'
+param serverContainerName string = 'server'
 
 @description('Blob Container name for model files')
-param modelsContainerName string = 'modelblobs'
+param modelsContainerName string = 'models'
+
+@description('Blob Container name for model files')
+param logsContainerName string = 'logs'
 
 @description('Name of key vault')
 param keyVaultName string
@@ -106,8 +109,12 @@ resource modelsContainer 'Microsoft.Storage/storageAccounts/blobServices/contain
   name: '${blobFs.name}/default/${modelsContainerName}'
 }
 
+resource modelsContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2021-04-01' = {
+  name: '${blobFs.name}/default/${logsContainerName}'
+}
+
 output oasisBlobNameSecretName string = oasisBlobNameSecretName
 output oasisBlobKeySecretName string = oasisBlobKeySecretName
 output serverBlobContainerName string = serverContainerName
 output modelsBlobContainerName string = modelsContainerName
-
+output logsBlobContainerName string = logsContainerName

--- a/azure/bicep/blob_account.bicep
+++ b/azure/bicep/blob_account.bicep
@@ -1,0 +1,113 @@
+@description('Resource location')
+param location string = resourceGroup().location
+
+@description('Blob Storage account name')
+param oasisBlobStorageAccountName string = substring('blob${uniqueString(resourceGroup().id)}', 0, 17)
+
+@description('Azure storage SKU type')
+@allowed([
+    'Premium_LRS'
+    'Premium_ZRS'
+    'Standard_GRS'
+    'Standard_GZRS'
+    'Standard_LRS'
+    'Standard_RAGRS'
+    'Standard_RAGZRS'
+    'Standard_ZRS'
+])
+param oasisBlobStorageAccountSKU string = 'Premium_LRS'
+
+@description('Tags for the resources')
+param tags object
+
+@description('Name of secret to store name of storage account')
+param oasisBlobNameSecretName string = 'oasisblob-name'
+
+@description('Name of secret to store key to storage account')
+param oasisBlobKeySecretName string = 'oasisblob-key'
+
+@description('Blob Container name for oasis shared file system')
+param serverContainerName string = 'serverblobs'
+
+@description('Blob Container name for model files')
+param modelsContainerName string = 'modelblobs'
+
+@description('Name of key vault')
+param keyVaultName string
+
+@description('The virtual network address prefixes')
+param allowedCidrRanges array = []
+
+@description('The sub network ID to allow access from')
+param subnetId string
+
+var allAccess = empty(allowedCidrRanges) || contains(allowedCidrRanges, '0.0.0.0/0')
+var defaultNetworkAction = allAccess ? 'Allow' : 'Deny'
+var allowedCidrRangesCleaned = allAccess ? [] : allowedCidrRanges
+
+
+resource blobFs 'Microsoft.Storage/storageAccounts@2021-09-01' = {
+    name: oasisBlobStorageAccountName
+    location: location
+    sku: {
+        name: oasisBlobStorageAccountSKU
+    }
+    kind: 'BlockBlobStorage'
+    tags: tags
+    properties: {
+        allowSharedKeyAccess: true
+        allowBlobPublicAccess: false
+        supportsHttpsTrafficOnly: true
+        minimumTlsVersion: 'TLS1_2'
+        networkAcls: {
+            bypass: 'Logging, AzureServices'
+            virtualNetworkRules: [
+                {
+                    id: subnetId
+                }
+            ]
+            ipRules: [for cidr in allowedCidrRangesCleaned: {
+                value: replace(cidr, '/32', '')
+                action: 'Allow'
+            }]
+            defaultAction: defaultNetworkAction
+        }
+    }
+}
+
+
+resource blobFsSecret 'Microsoft.KeyVault/vaults/secrets@2021-06-01-preview' = {
+  name: '${keyVaultName}/${oasisBlobKeySecretName}'
+  tags: tags
+  properties: {
+    attributes: {
+      enabled: true
+    }
+    value: '${listKeys(blobFs.id, blobFs.apiVersion).keys[0].value}'
+  }
+}
+
+resource blobFsNameSecret 'Microsoft.KeyVault/vaults/secrets@2021-06-01-preview' = {
+  name: '${keyVaultName}/${oasisBlobNameSecretName}'
+  tags: tags
+  properties: {
+    attributes: {
+      enabled: true
+    }
+    value: oasisBlobStorageAccountName
+  }
+}
+
+resource serverContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2021-04-01' = {
+  name: '${blobFs.name}/default/${serverContainerName}'
+}
+
+resource modelsContainer 'Microsoft.Storage/storageAccounts/blobServices/containers@2021-04-01' = {
+  name: '${blobFs.name}/default/${modelsContainerName}'
+}
+
+output oasisBlobNameSecretName string = oasisBlobNameSecretName
+output oasisBlobKeySecretName string = oasisBlobKeySecretName
+output serverBlobContainerName string = serverContainerName
+output modelsBlobContainerName string = modelsContainerName
+

--- a/azure/bicep/main.bicep
+++ b/azure/bicep/main.bicep
@@ -235,7 +235,7 @@ output modelsFileShareName string = storageAccount.outputs.modelsFileShareName
 // BlockBlob Storage outputs
 output oasisBlobNameSecretName string = blobAccount.outputs.oasisBlobNameSecretName
 output oasisBlobKeySecretName string = blobAccount.outputs.oasisBlobKeySecretName
-output serverBlobContainerName string = blobAccount.outputs.serverBlobContainerName
-output modelsBlobContainerName string = blobAccount.outputs.modelsBlobContainerName
+// output serverBlobContainerName string = blobAccount.outputs.serverBlobContainerName
+// output modelsBlobContainerName string = blobAccount.outputs.modelsBlobContainerName
 
 output aksCluster object = aks.outputs.aksCluster

--- a/azure/bicep/main.bicep
+++ b/azure/bicep/main.bicep
@@ -173,6 +173,23 @@ module storageAccount 'storage_account.bicep' = {
   ]
 }
 
+
+module blobAccount 'blob_account.bicep' = {
+  name: 'blobAccount'
+  params: {
+    location: location
+    keyVaultName: keyVault.outputs.keyVaultName
+    tags: tags
+    subnetId: vnet.outputs.subnetId
+    allowedCidrRanges: allowedCidrRanges
+  }
+
+  dependsOn: [
+    vnet
+  ]
+}
+
+
 module aks 'aks.bicep' = {
   name: 'aksDeploy'
   params: {
@@ -191,6 +208,7 @@ module aks 'aks.bicep' = {
 
   dependsOn: [
     storageAccount
+    blobAccount
   ]
 }
 
@@ -208,8 +226,16 @@ module registry 'registry.bicep' = {
   ]
 }
 
+// AzureFiles Storage outputs 
 output oasisFsNameSecretName string = storageAccount.outputs.oasisFsNameSecretName
 output oasisFsKeySecretName string = storageAccount.outputs.oasisFsKeySecretName
 output oasisFileShareName string = storageAccount.outputs.oasisFileShareName
 output modelsFileShareName string = storageAccount.outputs.modelsFileShareName
+
+// BlockBlob Storage outputs
+output oasisBlobNameSecretName string = blobAccount.outputs.oasisBlobNameSecretName
+output oasisBlobKeySecretName string = blobAccount.outputs.oasisBlobKeySecretName
+output serverBlobContainerName string = blobAccount.outputs.serverBlobContainerName
+output modelsBlobContainerName string = blobAccount.outputs.modelsBlobContainerName
+
 output aksCluster object = aks.outputs.aksCluster

--- a/deploy.sh
+++ b/deploy.sh
@@ -24,7 +24,7 @@ function usage {
   echo
   echo "  models         Install/update models defined in settings/helm/models-values.yaml"
   echo
-  echo "  logging        Install/update Fluent bit deamon-set for pods log collection in azure blob storage" 
+  echo "  logging        Install/update Fluent bit deamon-set for pods log collection in azure blob storage"
   echo
   echo "  update-kubectl Update kubectl context cluster"
   echo "  api [ls|run <id>]"
@@ -723,7 +723,7 @@ case "$deploy_type" in
     echo '  * https://github.com/fluent/helm-charts'
 
     helm repo add fluent https://fluent.github.io/helm-charts
-    helm upgrade -i fluent-bit fluent/fluent-bit -f "${SCRIPT_DIR}settings/helm/fluent-bit-values.yaml"
+    helm upgrade -i fluent-bit fluent/fluent-bit -f "${SCRIPT_DIR}/settings/helm/fluent-bit-values.yaml"
 
   ;;
   "api")

--- a/deploy.sh
+++ b/deploy.sh
@@ -24,6 +24,8 @@ function usage {
   echo
   echo "  models         Install/update models defined in settings/helm/models-values.yaml"
   echo
+  echo "  logging        Install/update Fluent bit deamon-set for pods log collection in azure blob storage" 
+  echo
   echo "  update-kubectl Update kubectl context cluster"
   echo "  api [ls|run <id>]"
   echo "                 Basic Oasis API commands"
@@ -713,6 +715,16 @@ case "$deploy_type" in
       echo "$0 purge [group|resources]"
       exit 0
     esac
+  ;;
+  "logging")
+    echo 'Installing Fluent bit helm chart - for documantion see:'
+    echo '  * https://docs.fluentbit.io/manual'
+    echo '  * https://docs.fluentbit.io/manual/pipeline/outputs/azure_blob'
+    echo '  * https://github.com/fluent/helm-charts'
+
+    helm repo add fluent https://fluent.github.io/helm-charts
+    helm upgrade -i fluent-bit fluent/fluent-bit -f "${SCRIPT_DIR}settings/helm/fluent-bit-values.yaml"
+
   ;;
   "api")
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -475,7 +475,6 @@ case "$deploy_type" in
         sed 's/^COPY/RUN true\nCOPY/g' < Dockerfile.api_server | \
             docker build -f - -t "${acr}/coreoasis/api_server:dev" .
       fi
-
       docker push "${acr}/coreoasis/api_server:dev"
     ;;
     "worker-controller")
@@ -558,6 +557,9 @@ case "$deploy_type" in
     oasis_fs_account_name="$(get_secret oasisfs-name)"
     oasis_fs_account_key="$(get_secret oasisfs-key)"
 
+    oasis_blob_account_name="$(get_secret oasisblob-name)"
+    oasis_blob_account_key="$(get_secret oasisblob-key)"
+
     key_vault_name="$(get_key_vault_name)"
     key_vault_tenant_id="$(get_key_vault_tenant_id)"
     aks_identity_client_id="$(get_aks_identity_client_id)"
@@ -569,6 +571,8 @@ case "$deploy_type" in
     helm_deploy "${SCRIPT_DIR}/settings/helm/platform-values.yaml" "${OASIS_PLATFORM_DIR}/kubernetes/charts/oasis-platform/" "$HELM_PLATFORM_NAME" \
       --set "azure.storageAccounts.oasisfs.accountName=${oasis_fs_account_name}" \
       --set "azure.storageAccounts.oasisfs.accountKey=${oasis_fs_account_key}" \
+      --set "azure.storageAccounts.serverblobs.accountName=${oasis_blob_account_name}" \
+      --set "azure.storageAccounts.serverblobs.accountKey=${oasis_blob_account_key}" \
       --set "azure.tenantId=${key_vault_tenant_id}" \
       --set "azure.secretProvider.keyvaultName=${key_vault_name}" \
       --set "azure.secretProvider.userAssignedIdentityClientID=${aks_identity_client_id}" \

--- a/deploy.sh
+++ b/deploy.sh
@@ -172,7 +172,9 @@ function helm_deploy() {
         sed "s/\${DNS_LABEL_NAME}/${DNS_LABEL_NAME}/g" | \
         sed "s/\${LOCATION}/${LOCATION}/g" | \
         sed "s/\${DOMAIN}/${domain}/g" | \
-        sed "s/\${LETSENCRYPT_EMAIL}/${LETSENCRYPT_EMAIL}/g" \
+        sed "s/\${LETSENCRYPT_EMAIL}/${LETSENCRYPT_EMAIL}/g" | \
+        sed "s/\${BLOB_STORAGE_ACCOUNT}/${BLOB_STORAGE_ACCOUNT}/g" | \
+        sed "s/\${BLOB_STORAGE_KEY}/${BLOB_STORAGE_KEY}/g" \
         > "$file"
 
     inputs+=" -f $file"
@@ -723,8 +725,12 @@ case "$deploy_type" in
     echo '  * https://github.com/fluent/helm-charts'
 
     helm repo add fluent https://fluent.github.io/helm-charts
-    helm upgrade -i fluent-bit fluent/fluent-bit -f "${SCRIPT_DIR}/settings/helm/fluent-bit-values.yaml"
+    #helm upgrade -i fluent-bit fluent/fluent-bit -f "${SCRIPT_DIR}/settings/helm/fluent-bit-values.yaml"
 
+    BLOB_STORAGE_ACCOUNT="$(get_secret oasisblob-name)"
+    TMP_VAR="$(get_secret oasisblob-key)"
+    BLOB_STORAGE_KEY=$(printf '%s' "$TMP_VAR" | sed 's/[&/\]/\\&/g')
+    helm_deploy "${SCRIPT_DIR}/settings/helm/fluent-bit-values.yaml" "fluent/fluent-bit" "fluent-bit"
   ;;
   "api")
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -724,13 +724,12 @@ case "$deploy_type" in
     echo '  * https://docs.fluentbit.io/manual/pipeline/outputs/azure_blob'
     echo '  * https://github.com/fluent/helm-charts'
 
+    update_kubectl_cluster
     helm repo add fluent https://fluent.github.io/helm-charts
     helm repo update
-    #helm upgrade -i fluent-bit fluent/fluent-bit -f "${SCRIPT_DIR}/settings/helm/fluent-bit-values.yaml"
 
     BLOB_STORAGE_ACCOUNT="$(get_secret oasisblob-name)"
-    TMP_VAR="$(get_secret oasisblob-key)"
-    BLOB_STORAGE_KEY=$(printf '%s' "$TMP_VAR" | sed 's/[&/\]/\\&/g')
+    BLOB_STORAGE_KEY=$(printf '%s' $(get_secret oasisblob-key) | sed 's/[&/\]/\\&/g')
     helm_deploy "${SCRIPT_DIR}/settings/helm/fluent-bit-values.yaml" "fluent/fluent-bit" "fluent-bit"
   ;;
   "api")

--- a/deploy.sh
+++ b/deploy.sh
@@ -725,6 +725,7 @@ case "$deploy_type" in
     echo '  * https://github.com/fluent/helm-charts'
 
     helm repo add fluent https://fluent.github.io/helm-charts
+    helm repo update
     #helm upgrade -i fluent-bit fluent/fluent-bit -f "${SCRIPT_DIR}/settings/helm/fluent-bit-values.yaml"
 
     BLOB_STORAGE_ACCOUNT="$(get_secret oasisblob-name)"

--- a/settings/helm/fluent-bit-values.yaml
+++ b/settings/helm/fluent-bit-values.yaml
@@ -49,20 +49,17 @@ config:
         K8S-Logging.Parser On
         K8S-Logging.Exclude On
 
-# Add timestamp to force blob filename rotation 
     [FILTER]
         Name    lua
         Match   kube.*
         script  /fluent-bit/scripts/filter_tag_time.lua
         call    tag_time
 
-# Select any logs marked as 'platform'
     [FILTER]
         Name        rewrite_tag
         Match        kube.*
         Rule         $kubernetes['labels']['app.kubernetes.io/instance'] platform platform.$kubernetes['pod_name'].$date false
 
-# Select any logs marked as 'model worker'
     [FILTER]
         Name        rewrite_tag
         Match        kube.*

--- a/settings/helm/fluent-bit-values.yaml
+++ b/settings/helm/fluent-bit-values.yaml
@@ -5,7 +5,7 @@
 daemonset:
   enabled: true
 
-# custom LUA filter 
+# custom LUA filter
 luaScripts:
   filter_tag_time.lua: |
     function tag_time(tag, timestamp, record)
@@ -68,9 +68,9 @@ config:
     [FILTER]
         Name        rewrite_tag
         Match        kube.*
-        Rule         $kubernetes['labels']['app.kubernetes.io/instance'] .*oasismodel.* model.$kubernetes['pod_name'].$date false
+        Rule         $kubernetes['labels']['app.kubernetes.io/name'] oasis-model model.$kubernetes['pod_name'].$date false
 
-# uncomment to remove all meta-data (saves space) 
+# uncomment to remove all meta-data (saves space)
 #    [FILTER]
 #        Name                modify
 #        Match               *

--- a/settings/helm/fluent-bit-values.yaml
+++ b/settings/helm/fluent-bit-values.yaml
@@ -1,20 +1,19 @@
 # values.yaml for fluent-bit helm chart
 # See: https://docs.fluentbit.io/manual/pipeline/outputs/azure_blob
-
-# errors
-#   [error] [output:azure_blob:azure_blob.0] cannot append content to blob
-#   The committed block count cannot exceed the maximum limit of 50,000 blocks.
-#
-#   see: https://github.com/fluent/fluent-bit/issues/2692
-#   Added filter to rotate files by date
-
-#       Tag               kube.<namespace_name>.<pod_name>.<container_name>.<container_id>
-
-
-
 # Enable Fluent Bit as a DaemonSet
+#
 daemonset:
   enabled: true
+
+# custom LUA filter 
+luaScripts:
+  filter_tag_time.lua: |
+    function tag_time(tag, timestamp, record)
+        new_record = record
+        new_record["date"] = os.date("%Y-%m")
+        return 1, timestamp, new_record
+    end
+
 
 # Configuration for Fluent Bit
 config:
@@ -50,20 +49,30 @@ config:
         K8S-Logging.Parser On
         K8S-Logging.Exclude On
 
+# Add timestamp to force blob filename rotation 
+    [FILTER]
+        Name    lua
+        Match   kube.*
+        script  /fluent-bit/scripts/filter_tag_time.lua
+        call    tag_time
+
+# Select any logs marked as 'platform'
     [FILTER]
         Name        rewrite_tag
         Match        kube.*
-        Rule         $kubernetes['labels']['app.kubernetes.io/instance'] platform platform.$kubernetes['pod_name'] false
+        Rule         $kubernetes['labels']['app.kubernetes.io/instance'] platform platform.$kubernetes['pod_name'].$date false
 
+# Select any logs marked as 'model worker'
     [FILTER]
         Name        rewrite_tag
         Match        kube.*
-        Rule         $kubernetes['labels']['app.kubernetes.io/instance'] models model.$kubernetes['pod_name'] false
+        Rule         $kubernetes['labels']['app.kubernetes.io/instance'] models model.$kubernetes['pod_name'].$date false
 
-    [FILTER]
-        Name                modify
-        Match               *
-        Remove_regex        ^(?!.*\blog\b).*
+# uncomment to remove all meta-data (saves space) 
+#    [FILTER]
+#        Name                modify
+#        Match               *
+#        Remove_regex        ^(?!.*\blog\b).*
 
   outputs: |
     [OUTPUT]
@@ -86,6 +95,7 @@ config:
         auto_create_container on
         tls                   on
 
+# Uncomment to store all other container logs 
 #    [OUTPUT]
 #        Name        azure_blob
 #        Match       kube.*

--- a/settings/helm/fluent-bit-values.yaml
+++ b/settings/helm/fluent-bit-values.yaml
@@ -20,7 +20,7 @@ daemonset:
 config:
   service: |
     [SERVICE]
-        Flush        1
+        Flush        60
         Log_Level    info
         HTTP_Server    On
         HTTP_Listen    0.0.0.0
@@ -32,7 +32,9 @@ config:
         Name tail
         Path /var/log/containers/*.log
         multiline.parser docker, cri
-        Mem_Buf_Limit 5MB
+        Mem_Buf_Limit 50MB
+        Buffer_Chunk_Size 2MB
+        Buffer_Max_Size   2MB
         Tag kube.*
 
   filters: |
@@ -84,12 +86,12 @@ config:
         auto_create_container on
         tls                   on
 
-    [OUTPUT]
-        Name        azure_blob
-        Match       kube.*
-        account_name          ${BLOB_STORAGE_ACCOUNT}
-        shared_key            ${BLOB_STORAGE_KEY}
-        path                  kubernetes
-        container_name        logs
-        auto_create_container on
-        tls                   on
+#    [OUTPUT]
+#        Name        azure_blob
+#        Match       kube.*
+#        account_name          ${BLOB_STORAGE_ACCOUNT}
+#        shared_key            ${BLOB_STORAGE_KEY}
+#        path                  kubernetes
+#        container_name        logs
+#        auto_create_container on
+#        tls                   on

--- a/settings/helm/fluent-bit-values.yaml
+++ b/settings/helm/fluent-bit-values.yaml
@@ -10,7 +10,7 @@ luaScripts:
   filter_tag_time.lua: |
     function tag_time(tag, timestamp, record)
         new_record = record
-        new_record["date"] = os.date("%Y-%m")
+        new_record["date"] = os.date("%Y-%m-%d")
         return 1, timestamp, new_record
     end
 
@@ -19,7 +19,7 @@ luaScripts:
 config:
   service: |
     [SERVICE]
-        Flush        60
+        Flush        30
         Log_Level    info
         HTTP_Server    On
         HTTP_Listen    0.0.0.0

--- a/settings/helm/fluent-bit-values.yaml
+++ b/settings/helm/fluent-bit-values.yaml
@@ -20,7 +20,7 @@ config:
   service: |
     [SERVICE]
         Flush        60
-        Log_Level    info
+        Log_Level    debug
         HTTP_Server    On
         HTTP_Listen    0.0.0.0
         HTTP_Port      2020

--- a/settings/helm/fluent-bit-values.yaml
+++ b/settings/helm/fluent-bit-values.yaml
@@ -20,7 +20,7 @@ config:
   service: |
     [SERVICE]
         Flush        60
-        Log_Level    debug
+        Log_Level    info
         HTTP_Server    On
         HTTP_Listen    0.0.0.0
         HTTP_Port      2020

--- a/settings/helm/fluent-bit-values.yaml
+++ b/settings/helm/fluent-bit-values.yaml
@@ -1,0 +1,30 @@
+# values.yaml for fluent-bit helm chart 
+# See: https://docs.fluentbit.io/manual/pipeline/outputs/azure_blob
+
+# Enable Fluent Bit as a DaemonSet
+daemonset:
+  enabled: true
+
+# Configuration for Fluent Bit
+config:
+  service: |
+    [SERVICE]
+        Flush        1
+        Log_Level    info
+
+  inputs: |
+    [INPUT]
+        Name        tail
+        Path        /var/log/containers/*.log
+        Tag         kube.*
+
+  outputs: |
+    [OUTPUT]
+        Name        azure_blob
+        Match       *
+        account_name          ${BLOB_ACCOUNT_NAME}
+        shared_key            ${BLOB_ACCOUNT_KEY}
+        path                  kubernetes
+        container_name        logs
+        auto_create_container on
+        tls                   on

--- a/settings/helm/fluent-bit-values.yaml
+++ b/settings/helm/fluent-bit-values.yaml
@@ -1,5 +1,16 @@
-# values.yaml for fluent-bit helm chart 
+# values.yaml for fluent-bit helm chart
 # See: https://docs.fluentbit.io/manual/pipeline/outputs/azure_blob
+
+# errors
+#   [error] [output:azure_blob:azure_blob.0] cannot append content to blob
+#   The committed block count cannot exceed the maximum limit of 50,000 blocks.
+#
+#   see: https://github.com/fluent/fluent-bit/issues/2692
+#   Added filter to rotate files by date
+
+#       Tag               kube.<namespace_name>.<pod_name>.<container_name>.<container_id>
+
+
 
 # Enable Fluent Bit as a DaemonSet
 daemonset:
@@ -18,16 +29,66 @@ config:
 
   inputs: |
     [INPUT]
-        Name        tail
-        Path        /var/log/containers/*.log
-        Tag         kube.*
+        Name tail
+        Path /var/log/containers/*.log
+        multiline.parser docker, cri
+        Mem_Buf_Limit 5MB
+        Tag kube.*
+
+  filters: |
+    [FILTER]
+        Name        kubernetes
+        Match       kube.*
+        Kube_URL    https://kubernetes.default.svc:443
+        Kube_CA_File       /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+        Kube_Token_File    /var/run/secrets/kubernetes.io/serviceaccount/token
+        Kube_Tag_Prefix    kube.var.log.containers.
+        Merge_Log    On
+        Keep_Log     Off
+        K8S-Logging.Parser On
+        K8S-Logging.Exclude On
+
+    [FILTER]
+        Name        rewrite_tag
+        Match        kube.*
+        Rule         $kubernetes['labels']['app.kubernetes.io/instance'] platform platform.$kubernetes['pod_name'] false
+
+    [FILTER]
+        Name        rewrite_tag
+        Match        kube.*
+        Rule         $kubernetes['labels']['app.kubernetes.io/instance'] models model.$kubernetes['pod_name'] false
+
+    [FILTER]
+        Name                modify
+        Match               *
+        Remove_regex        ^(?!.*\blog\b).*
 
   outputs: |
     [OUTPUT]
         Name        azure_blob
-        Match       *
-        account_name          ${BLOB_ACCOUNT_NAME}
-        shared_key            ${BLOB_ACCOUNT_KEY}
+        Match       model.*
+        account_name          ${BLOB_STORAGE_ACCOUNT}
+        shared_key            ${BLOB_STORAGE_KEY}
+        path                  models
+        container_name        logs
+        auto_create_container on
+        tls                   on
+
+    [OUTPUT]
+        Name        azure_blob
+        Match       platform.*
+        account_name          ${BLOB_STORAGE_ACCOUNT}
+        shared_key            ${BLOB_STORAGE_KEY}
+        path                  platform
+        container_name        logs
+        auto_create_container on
+        tls                   on
+
+    [OUTPUT]
+        Name        azure_blob
+        Match       kube.*
+        account_name          ${BLOB_STORAGE_ACCOUNT}
+        shared_key            ${BLOB_STORAGE_KEY}
         path                  kubernetes
         container_name        logs
         auto_create_container on

--- a/settings/helm/fluent-bit-values.yaml
+++ b/settings/helm/fluent-bit-values.yaml
@@ -97,12 +97,12 @@ config:
         auto_create_container on
         tls                   on
 
-    [OUTPUT]
-        Name        azure_blob
-        Match       kube.*
-        account_name          ${BLOB_STORAGE_ACCOUNT}
-        shared_key            ${BLOB_STORAGE_KEY}
-        path                  kubernetes
-        container_name        logs
-        auto_create_container on
-        tls                   on
+#    [OUTPUT]
+#        Name        azure_blob
+#        Match       kube.*
+#        account_name          ${BLOB_STORAGE_ACCOUNT}
+#        shared_key            ${BLOB_STORAGE_KEY}
+#        path                  kubernetes
+#        container_name        logs
+#        auto_create_container on
+#        tls                   on

--- a/settings/helm/fluent-bit-values.yaml
+++ b/settings/helm/fluent-bit-values.yaml
@@ -11,6 +11,10 @@ config:
     [SERVICE]
         Flush        1
         Log_Level    info
+        HTTP_Server    On
+        HTTP_Listen    0.0.0.0
+        HTTP_Port      2020
+        Health_Check On
 
   inputs: |
     [INPUT]

--- a/settings/helm/fluent-bit-values.yaml
+++ b/settings/helm/fluent-bit-values.yaml
@@ -92,13 +92,12 @@ config:
         auto_create_container on
         tls                   on
 
-# Uncomment to store all other container logs 
-#    [OUTPUT]
-#        Name        azure_blob
-#        Match       kube.*
-#        account_name          ${BLOB_STORAGE_ACCOUNT}
-#        shared_key            ${BLOB_STORAGE_KEY}
-#        path                  kubernetes
-#        container_name        logs
-#        auto_create_container on
-#        tls                   on
+    [OUTPUT]
+        Name        azure_blob
+        Match       kube.*
+        account_name          ${BLOB_STORAGE_ACCOUNT}
+        shared_key            ${BLOB_STORAGE_KEY}
+        path                  kubernetes
+        container_name        logs
+        auto_create_container on
+        tls                   on

--- a/settings/helm/fluent-bit-values.yaml
+++ b/settings/helm/fluent-bit-values.yaml
@@ -65,6 +65,11 @@ config:
         Match        kube.*
         Rule         $kubernetes['labels']['app.kubernetes.io/instance'] models model.$kubernetes['pod_name'].$date false
 
+    [FILTER]
+        Name        rewrite_tag
+        Match        kube.*
+        Rule         $kubernetes['labels']['app.kubernetes.io/instance'] .*oasismodel.* model.$kubernetes['pod_name'].$date false
+
 # uncomment to remove all meta-data (saves space) 
 #    [FILTER]
 #        Name                modify

--- a/settings/helm/platform-values.yaml
+++ b/settings/helm/platform-values.yaml
@@ -61,6 +61,9 @@ azure:
   storageAccounts:
     oasisfs:
       secretName: oasis-storage-account
+    serverblobs:
+      secretName: oasis-blob-account
+
   secretProvider:
     secrets:
       server-db:


### PR DESCRIPTION
### Stream container logs into Azure blob storage 
Uses [Fluent Bit](https://docs.fluentbit.io/manual) which works as a [DaemonSet](https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/) to stream all container logs into a separate azure storage account hosting blob storage. 

The additional storage account is created when install the platform using `./deploy.sh base`  but no logs are created until Fluent Bit is installed using  `./deploy.sh logging`

There are three sections under the storage container `logs`
* `platform` ~ all containers annotated as core to running the OasisPlatform
* `models` ~ all model worker logs are stored here
* ` kubernetes ` ~ everything else

### Configuration 
The data stream Fluent Bit uses is defined in [settings/helm/fluent-bit-values.yaml](https://github.com/OasisLMF/OasisAzureDeployment/pull/28/files#diff-b966a55118b468741eafcff88358e5b89619a590f16ba968ef922a3f3989b47c) there are lots more options available, this is a basic starting point to get logs stored in azure.  

### Possible Issues and improvements 
1. There seems to be an issue with Fluent-bit's AzureBlobStorage plugin https://github.com/fluent/fluent-bit/issues/2692
After sometime it errors out with 
```
[error] [output:azure_blob:azure_blob.0] cannot append content to blob
The committed block count cannot exceed the maximum limit of 50,000 blocks.
```
A suggested workaround is rewriting the `$TAG` value to include a partial date or timestamp. that should rotate the blobs used for storage. 

2. Credentials aren't gracefully managed
I've used the charts from [github.com/fluent/helm-charts](https://github.com/fluent/helm-charts/tree/main/charts/fluent-bit) and wasn't sure how to add in the storage credentials, current implantation works.. but its a kludge. 

Its probably better to roll this into the [oasis-monitoring](https://github.com/OasisLMF/OasisPlatform/tree/main/kubernetes/charts/oasis-monitoring) as a general feature, and use the SecretProvider class already setup.  

3. Extend feature by adding a log viewer like https://grafana.com/docs/loki/latest/
--- 


### Log Output
Most of the the meta-data can be stripped way before storage, this is mainly a space saving measurement, to log everything comment out the following lines:
 https://github.com/OasisLMF/OasisAzureDeployment/blob/9c60fc896c24cb860628d4e246a9b4ff913dfc56/settings/helm/fluent-bit-values.yaml#L61-L64


The logs are stored as key/value pairs in JSON with the main section key called `logs`. 

```
$ tail -n 2 model.worker-oasislmf-piwind-2-v2-84df59b485-c2594
{"@timestamp":"2024-08-02T18:40:41.203582Z","log":"[2024-08-02 18:40:41,203: INFO/ForkPoolWorker-2] Store file: /var/log/oasis/tasks/84e7283d2c014b1fa3c625461cedb6f2_cleanup-losses-generation.log -> /shared-fs/f166c1bb7f744646ba5c8526d35637e9.log"}
{"@timestamp":"2024-08-02T18:40:41.327329Z","log":"[2024-08-02 18:40:41,326: INFO/ForkPoolWorker-2] Task cleanup_losses_generation[9a763216-80e5-4be9-b698-a9659d280356] succeeded in 0.40974743199996055s: {'oasis_files_dir': '/tmp/run/analysis-1_losses-84e7283d2c014b1fa3c625461cedb6f2/input-data', 'check_oed': True, 'analysis_settings_json': '/tmp/run/analysis-1_losses-84e7283d2c014b1fa3c625461cedb6f2/analysis_settings.json', 'model_settings_json': '/home/worker/model/meta-data/model_settings.json', 'user_data_dir': '/tmp/run/analysis-1_losses-84e7283d2c014b1fa3c625461cedb6f2/user-data', 'model_data_dir': '/home/worker/model/model_data/PiWind', 'copy_model_data': False, 'model_run_dir': '/tmp/run/analysis-1_losses-84e7283d2c014b1fa3c625461cedb6f2/run-data', 'ktools_legacy_stream': False, 'fmpy': True, 'ktools_alloc_rule_il': 2, 'ktools_alloc_rule_ri': 3, 'summarypy': False, 'check_missing_inputs': False, 'verbose': True, 'ktools_num_processes': -1, 'ktools_event_shuffle': 1, 'ktools_alloc_rule_gul': 1, 'ktools_num_gul_per_lb': 0, 'ktools_num_fm_per_lb': 0, 'ktools_disable_guard': False, 'ktools_fifo_relative': False, 'modelpy': False, 'gulpy': False, 'gulpy_random_generator': 1, 'gulmc': True, 'gulmc_random_gen...', ...}"}
``` 

The `jq` tool can be used to get a clear view of the raw container logs:
```
$ head -n 20 model.worker-oasislmf-piwind-2-v2-84df59b485-c2594 | jq -r '.log'
Waiting for services: broker celery-db
available
wait-for-it.sh: waiting 60 seconds for broker:5672
wait-for-it.sh: broker:5672 is available after 0 seconds
wait-for-it.sh: waiting 60 seconds for oasis-vgyn5yzu3mcfq.postgres.database.azure.com:5432
wait-for-it.sh: oasis-vgyn5yzu3mcfq.postgres.database.azure.com:5432 is available after 0 seconds
/home/worker/.local/lib/python3.10/site-packages/oasislmf/__init__.py:63: UserWarning: imports from 'oasislmf.model_preparation' are deprecated. Import by using 'oasislmf.preparation' instead.
  warnings.warn(
 
 -------------- celery@worker-oasislmf-piwind-2-v2-84df59b485-c2594 v5.3.0 (emerald-rush)
--- ***** ----- 
-- ******* ---- Linux-5.15.0-1067-azure-x86_64-with-glibc2.35 2024-08-02 18:36:42
- *** --- * --- 
- ** ---------- [config]
- ** ---------- .> app:         __main__:0x7f5387068070
- ** ---------- .> transport:   amqp://rabbit:**@broker:5672//
- ** ---------- .> results:     postgresql+psycopg2://celery:**@oasis-vgyn5yzu3mcfq.postgres.database.azure.com:5432/celery
- *** --- * --- .> concurrency: 4 (prefork)
-- ******* ---- .> task events: OFF (enable -E to monitor tasks in this worker)
--- ***** ----- 

```



### Example Screenshots: 

![Screenshot from 2024-08-02 15-02-07](https://github.com/user-attachments/assets/a1eea9a9-27c6-49f9-a596-269be5a6cd68)

![Screenshot from 2024-08-02 15-02-18](https://github.com/user-attachments/assets/59fe9ae4-cd4e-4676-9e3a-398837b3c973)

![Screenshot from 2024-08-02 15-02-36](https://github.com/user-attachments/assets/3511e364-aa97-46f2-9061-20b32a6ceb27)


 
